### PR TITLE
Fix: mention customization bugs

### DIFF
--- a/components/admin/GradeField.tsx
+++ b/components/admin/GradeField.tsx
@@ -18,8 +18,9 @@ export default ({value}: GradeInterface) => {
   const activeGrade = election.grades.filter((g) => g.active);
   const numGrades = activeGrade.length;
 
+  const id = `${grade.value}`
   const {attributes, listeners, setNodeRef, transform, transition} =
-    useSortable({id: grade.value});
+    useSortable({ id });
 
   const [visible, setVisible] = useState<boolean>(false);
   const toggle = () => setVisible((v) => !v);

--- a/components/admin/GradeModalSet.tsx
+++ b/components/admin/GradeModalSet.tsx
@@ -22,7 +22,7 @@ const GradeModal = ({isOpen, toggle, value}) => {
 
     dispatch({
       type: ElectionTypes.GRADE_SET,
-      position: election.grades.map((g) => g.value).indexOf(value),
+      position: value,
       field: 'name',
       value: name,
     });

--- a/components/admin/Grades.tsx
+++ b/components/admin/Grades.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dnd-kit/core';
 import {
   arrayMove,
-  rectSwappingStrategy,
+  horizontalListSortingStrategy,
   SortableContext,
   sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
@@ -122,7 +122,7 @@ const Grades = () => {
             >
               <SortableContext
                 items={grades.map((g) => `${g.value}`)}
-                strategy={rectSwappingStrategy}
+                strategy={horizontalListSortingStrategy}
               >
                 {grades.map((grade) => (
                   <Col key={grade.value} className="col col-auto">

--- a/components/admin/Grades.tsx
+++ b/components/admin/Grades.tsx
@@ -93,8 +93,8 @@ const Grades = () => {
   const handleDragEnd = ({ active, over }) => {
     if (active.id !== over.id) {
       const values = grades.map((g) => g.value);
-      const oldIndex = values.indexOf(active.id);
-      const newIndex = values.indexOf(over.id);
+      const oldIndex = values.indexOf(parseInt(active.id));
+      const newIndex = values.indexOf(parseInt(over.id));
       dispatch({
         type: ElectionTypes.SET,
         field: 'grades',
@@ -121,7 +121,7 @@ const Grades = () => {
               onDragEnd={handleDragEnd}
             >
               <SortableContext
-                items={grades.map((g) => g.value)}
+                items={grades.map((g) => `${g.value}`)}
                 strategy={rectSwappingStrategy}
               >
                 {grades.map((grade) => (


### PR DESCRIPTION
Il y avait quelques bugs sur la personnalisation des mentions : 

- La personnalisation du libellé d'une mention mettait à jour une autre mention
- La dernière mention n'était pas draggable (à cause de sa valeur 0 qui est falsy)
- Le réordonnancement des mention en cours de drag n drop n'était pas conforme avec ce qu'il se passait réellement après avoir droppé la mention