### PR TITLE
Fix grade color mapping based on election rank

### DIFF
--- a/components/ballot/GradeInput.tsx
+++ b/components/ballot/GradeInput.tsx
@@ -2,7 +2,7 @@ import {useState, useCallback, useEffect, MouseEvent} from 'react';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faCheck} from '@fortawesome/free-solid-svg-icons';
 import {useBallot, BallotTypes} from '@services/BallotContext';
-import {getGradeColor} from '@services/grades';
+import { getRankedGradeColor } from '@services/grades';
 
 
 const GradeName = ({name, active}) => {
@@ -32,13 +32,31 @@ const GradeInput = ({gradeId, candidateId}: GradeInputInterface) => {
   };
 
   const active = ballot.votes.some(b => b.gradeId === gradeId && b.candidateId === candidateId)
-  const color = active ? getGradeColor(grade.value, numGrades) : '#C3BFD8';
+
+  let displayBackgroundColor: string = '#C3BFD8'; // Inactive background
+  let displayBoxShadowColor: string = '#8F88BA';  // Inactive shadow
+
+  if (active) {
+    const activeColor = getRankedGradeColor(gradeId, ballot.election.grades);
+    if (activeColor) {
+      displayBackgroundColor = activeColor;
+      displayBoxShadowColor = activeColor;
+    } else {
+      console.warn(
+        `GradeInput: Failed to determine active color. Using fallback styling. ` +
+        `GradeId: ${gradeId}, Grade name: '${grade.name}'.`
+      );
+    }
+  }
 
   return (<>
     <div
       className={`justify-content-center d-none d-md-flex my-1 rounded-1 px-2 py-1 fs-5 text-white ms-3`}
       onClick={handleClick}
-      style={{backgroundColor: color, boxShadow: active ? `0px 2px 0px ${color}` : "0px 2px 0px #8F88BA"}}
+      style={{
+        backgroundColor: displayBackgroundColor,
+        boxShadow: `0px 2px 0px ${displayBoxShadowColor}`
+      }}
     >
       <GradeName name={grade.name} active={active} />
     </div >
@@ -46,8 +64,8 @@ const GradeInput = ({gradeId, candidateId}: GradeInputInterface) => {
       className={`d-flex d-md-none my-1 justify-content-center py-2 text-white`}
       onClick={handleClick}
       style={{
-        backgroundColor: color,
-        boxShadow: active ? `0px 2px 0px ${color}` : "0px 2px 0px #8F88BA",
+        backgroundColor: displayBackgroundColor,
+        boxShadow: `0px 2px 0px ${displayBoxShadowColor}`,
         width: "200px"
       }}
     >

--- a/services/grades.ts
+++ b/services/grades.ts
@@ -1,3 +1,5 @@
+import { GradePayload } from './api';
+
 export const gradeColors = [
   "#990000",
   "#C23D13",
@@ -42,3 +44,52 @@ export const getGradeColor = (gradeIdx: number, numGrades: number): string => {
   }
   return colors[gradeIdx]
 }
+
+export const getRankedGradeColor = (gradeId: number, allGrades: ReadonlyArray<GradePayload>): string | undefined => {
+  const numGrades = allGrades.length;
+
+  if (numGrades === 0) {
+    console.warn("getRankedGradeColor: Called with no election grades.");
+    return undefined;
+  }
+
+  if (gradeId < 0 || gradeId >= numGrades) {
+    console.warn(
+      `getRankedGradeColor: gradeId is out of bounds for allGrades. ` +
+      `GradeId: ${gradeId}, AllGrades length: ${numGrades}.`
+    );
+    return undefined;
+  }
+
+  const currentGrade = allGrades[gradeId];
+  const allValues = allGrades.map(g => g.value);
+  const sortedValues = [...allValues].sort((a, b) => a - b);
+  const rank = sortedValues.indexOf(currentGrade.value);
+
+  if (rank === -1) {
+    console.warn(
+      `getRankedGradeColor: Could not determine rank for grade. ` +
+      `Grade Name: ${currentGrade.name}, Value: ${currentGrade.value}. ` +
+      `Sorted values: [${sortedValues.join(', ')}]`
+    );
+    return undefined;
+  }
+
+  try {
+    const color = getGradeColor(rank, numGrades);
+    if (color === undefined) {
+        console.warn(
+            `getRankedGradeColor: Original getGradeColor returned undefined. ` +
+            `Rank: ${rank}, NumGrades ${numGrades}.`
+        );
+    }
+    return color;
+  } catch (error) {
+    console.error(
+      `getRankedGradeColor: Error calling original getGradeColor. ` +
+      `Rank: ${rank}, NumGrades: ${numGrades}. Grade Name: ${currentGrade.name}.`,
+      error
+    );
+    return undefined;
+  }
+};


### PR DESCRIPTION
Previously, GradeInput could display grades incorrectly. When `grade.value` was used directly as an index argument for `getGradeColor()`, it could be out of bounds for the colors available for the current election, leading to an `undefined` background color. Since the component uses a `text-white` class, this rendered the grade effectively "all white" against the typically light background of the page.

Let's fix this issue by implementing a new `getRankedGradeColor()` function to encapsulate the ranking logic, and then using it instead of `getGradeColor()`.

This new function takes the gradeId (the index of the specific grade within the election's list of grades) and the entire array of election.grades as arguments. It then performs the ranking and calls the original `getGradeColor()`.

In more details, the rank for each grade in the election is determined by:

    - Extracting all `value` properties from all the grades.
    - Sorting these values numerically (ascending).
    - Finding the index of the current `grade.value` in this sorted list.

This rank (0 for the worst grade in the election, N-1 for the best) is then passed to `getGradeColor()`, ensuring the color correctly reflects the grade's relative quality within the context of the current election's available grades.

Additionally, in "GradeInput.tsx", the assignment of colors now explicitly checks for a valid color. If the rank is undefined, it defaults to the inactive color, preventing the "all white" issue in edge cases where rank calculation might fail.

This should fix https://github.com/MieuxVoter/majority-judgment-web-app/issues/109