### PR TITLE
Fixed: Grade personalization become inactive when moving to next step

### DIFF
--- a/components/admin/ConfirmRevertCustomGradesModal.tsx
+++ b/components/admin/ConfirmRevertCustomGradesModal.tsx
@@ -1,0 +1,51 @@
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import {useTranslation} from 'next-i18next';
+import {Button, Modal, ModalBody} from 'reactstrap';
+
+const ConfirmRevertCustomGradesModal = ({isOpen, onConfirm, toggle})=> {
+  const {t} = useTranslation();
+  return (
+    <Modal
+      isOpen={isOpen}
+      toggle={toggle}
+      keyboard={true}
+      className="modal_grade"
+    >
+      <div className="modal-header p-4">
+        <h4 className="modal-title">{t('admin.revert-custom-grades')}</h4>
+        <button
+          type="button"
+          onClick={toggle}
+          className="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+        ></button>
+      </div>
+
+      <ModalBody className="p-4">
+        <p>{t('admin.revert-custom-grades-desc')}</p>
+
+        <div className="mt-3 gap-2 d-flex mb-3 justify-content-between">
+            <Button
+              color="dark"
+              onClick={toggle}
+              className=""
+              outline={true}
+              icon={faArrowLeft}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+            color="danger"
+            outline={true}
+            onClick={onConfirm}
+            >
+            {t('admin.step-confirm')}
+            </Button>
+        </div>
+      </ModalBody>
+    </Modal>
+  );
+}
+
+export default ConfirmRevertCustomGradesModal;

--- a/components/admin/Grades.tsx
+++ b/components/admin/Grades.tsx
@@ -26,6 +26,7 @@ import GradeField from './GradeField';
 import GradeModalAdd from './GradeModalAdd';
 import { getDefaultGrades, gradeColors } from '@services/grades';
 import Switch from '@components/Switch';
+import ConfirmRevertCustomGradesModal from './ConfirmRevertCustomGradesModal';
 
 const AddField = () => {
   const { t } = useTranslation();
@@ -63,9 +64,19 @@ const Grades = () => {
   const [election, dispatch] = useElection();
   const grades = election.grades;
   const [visible, setVisible] = useState(JSON.stringify(election.grades) !== JSON.stringify(getDefaultGrades(t)));
+  const [modalRevert, setModalRevert] = useState(false);
+
+  const toggleModalRevert = () => {
+    setModalRevert(!modalRevert);
+  };
 
   const toggle = () => {
     if (visible) {
+      if (JSON.stringify(election.grades) !== JSON.stringify(getDefaultGrades(t))) {
+        toggleModalRevert();
+        return;
+      }
+
       dispatch({
         type: ElectionTypes.SET,
         field: 'grades',
@@ -141,6 +152,19 @@ const Grades = () => {
           </Row>
         </>
       )}
+      <ConfirmRevertCustomGradesModal
+        isOpen={modalRevert}
+        toggle={toggleModalRevert}
+        onConfirm={() => {
+          dispatch({
+            type: ElectionTypes.SET,
+            field: 'grades',
+            value: getDefaultGrades(t),
+          });
+          setVisible(false);
+          setModalRevert(false);
+        }}
+      />
     </Container>
   );
 };

--- a/components/admin/Grades.tsx
+++ b/components/admin/Grades.tsx
@@ -24,7 +24,7 @@ import { DEFAULT_GRADES } from '@services/constants';
 import { ElectionTypes, useElection } from '@services/ElectionContext';
 import GradeField from './GradeField';
 import GradeModalAdd from './GradeModalAdd';
-import { gradeColors } from '@services/grades';
+import { getDefaultGrades, gradeColors } from '@services/grades';
 import Switch from '@components/Switch';
 
 const AddField = () => {
@@ -62,11 +62,19 @@ const Grades = () => {
 
   const [election, dispatch] = useElection();
   const grades = election.grades;
-  const numGrades = grades.filter((g) => g.active).length;
-  const disabled = numGrades >= gradeColors.length;
+  const [visible, setVisible] = useState(JSON.stringify(election.grades) !== JSON.stringify(getDefaultGrades(t)));
 
-  const [visible, setVisible] = useState(false);
-  const toggle = () => setVisible((m) => !m);
+  const toggle = () => {
+    if (visible) {
+      dispatch({
+        type: ElectionTypes.SET,
+        field: 'grades',
+        value: getDefaultGrades(t),
+      });
+    }
+
+    setVisible((m) => !m)
+  };
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -77,16 +85,12 @@ const Grades = () => {
 
   useEffect(() => {
     if (election.grades.length < 2) {
-      const defaultGrades = DEFAULT_GRADES.map((g, i) => ({
-        name: t(g),
-        value: DEFAULT_GRADES.length - 1 - i,
-        active: true,
-      }));
       dispatch({
         type: ElectionTypes.SET,
         field: 'grades',
-        value: defaultGrades,
+        value: getDefaultGrades(t),
       });
+      setVisible(false);
     }
   }, []);
 

--- a/public/locales/en/resource.json
+++ b/public/locales/en/resource.json
@@ -120,6 +120,8 @@
     "grades.passable": "Passable",
     "grades.inadequate": "Inadequate",
     "grades.mediocre": "Mediocre",
+    "admin.revert-custom-grades": "Revert to default grades",
+    "admin.revert-custom-grades-desc": "Reverting to default grades will delete all your custom grades (Press toggle on won't make them reappear).",
     "admin.admin-title": "Voting management panel",
     "admin.close-election": "Close the election",
     "admin.open-election": "Open the election",

--- a/public/locales/fr/resource.json
+++ b/public/locales/fr/resource.json
@@ -120,6 +120,8 @@
     "grades.good": "Bien",
     "grades.passable": "Passable",
     "grades.inadequate": "Insuffisant",
+    "admin.revert-custom-grades": "Revenir aux mentions par défaut",
+    "admin.revert-custom-grades-desc": "Toutes vos mentions ajoutées/modifiées seront supprimées (réactiver la personnalisation des mentions ne fera pas réapparaître votre configuration actuelle).",
     "admin.admin-title": "Administration du vote",
     "admin.close-election": "Clôturer l'élection",
     "admin.open-election": "Ré-ouvrir l'élection",

--- a/services/grades.ts
+++ b/services/grades.ts
@@ -1,4 +1,5 @@
 import { GradePayload } from './api';
+import { DEFAULT_GRADES } from './constants';
 
 export const gradeColors = [
   "#990000",
@@ -31,6 +32,14 @@ export const gradeClass = [
 ];
 
 export const gradeValues = [0, 1, 2, 3, 4, 5, 6, 7];
+
+export const getDefaultGrades = (t: (key: string) => string): ReadonlyArray<{name:string, value:number, active:boolean}> =>{
+  return DEFAULT_GRADES.map((g, i) => ({
+    name: t(g),
+    value: DEFAULT_GRADES.length - 1 - i,
+    active: true,
+  }))
+}
 
 export const getGradeColor = (gradeIdx: number, numGrades: number): string => {
   const extraColors = gradeColors.length - numGrades;


### PR DESCRIPTION
- Set toggle enable depending if the grade are the same than defaults.  
- Add modal to prevent removing grades unintentionally

<details><summary>Before</summary>

https://github.com/user-attachments/assets/0ecc634e-47b5-459e-a4f6-db6d679a8ce5
</details>


<details><summary>After</summary>

https://github.com/user-attachments/assets/ebb7b5b1-f47c-45b1-99a8-8f0b5d8a6c2b
</details>
