### PR TITLE
Adapt to new error payload

### DIFF
--- a/components/ErrorDisplay.tsx
+++ b/components/ErrorDisplay.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Container } from 'reactstrap';
+import PatternedBackground from '@components/PatternedBackground';
+import Button from '@components/Button';
+
+interface ErrorDisplayProps {
+  title: string;
+  message: string;
+  buttonText: string;
+  onButtonClick: () => void;
+}
+
+const ErrorDisplay = ({ title, message, buttonText, onButtonClick }: ErrorDisplayProps) => {
+  return (
+    <PatternedBackground>
+      <Container
+        className="d-flex flex-column justify-content-center align-items-center text-center text-white"
+        style={{ minHeight: '100vh' }}
+      >
+        <h4 className="mb-4">{title}</h4>
+        <p className="mb-4">{message}</p>
+        <Button color="secondary" className="bg-blue" onClick={onButtonClick}>
+          {buttonText}
+        </Button>
+      </Container>
+    </PatternedBackground>
+  );
+};
+
+export default ErrorDisplay;

--- a/components/WaitingBallot.tsx
+++ b/components/WaitingBallot.tsx
@@ -122,7 +122,7 @@ const Info = ({ballot, error}: WaitingBallotInterface) => {
   if (!ballot) return null;
 
   if (error) {
-    return <ErrorMessage>{error.detail[0].msg}</ErrorMessage>;
+    return <ErrorMessage>{error.message}</ErrorMessage>;
   }
 
   return (

--- a/components/WaitingElection.tsx
+++ b/components/WaitingElection.tsx
@@ -47,8 +47,8 @@ const InfoElection = ({election, error, display}: InfoElectionInterface) => {
       }}
     >
       <div className="d-flex flex-column align-items-center">
-        {error && error.detail ? (
-          <ErrorMessage>{error.detail[0].msg}</ErrorMessage>
+        {error ? (
+          <ErrorMessage>{error.message}</ErrorMessage>
         ) : null}
 
         {election && election.ref ? (

--- a/components/ballot/TitleBar.tsx
+++ b/components/ballot/TitleBar.tsx
@@ -1,7 +1,7 @@
 import {useRouter} from 'next/router';
 import Button from '@components/Button';
 import {useTranslation} from 'next-i18next';
-import {getElection, castBallot, apiErrors, ElectionPayload, CandidatePayload, GradePayload} from '@services/api';
+import {getElection, castBallot, ElectionPayload, CandidatePayload, GradePayload} from '@services/api';
 import {getFormattedDatetime, getLocaleShort} from '@services/utils';
 import {faCalendarDays} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';

--- a/pages/admin/[pid]/[tid].tsx
+++ b/pages/admin/[pid]/[tid].tsx
@@ -336,7 +336,7 @@ const ManageElection = ({ token }:{token:(string|undefined)}) => {
       token
     );
 
-    if (response.status === 200 && 'ref' in response) {
+    if (!('error' in response)) {
       try {
         await sendEmailsDownloadQRCodesPDFAndDisplayInvites({
           electionName: election.name,
@@ -399,7 +399,7 @@ const ManageElection = ({ token }:{token:(string|undefined)}) => {
     try {
       const response = await openElection(election, token);
 
-      if (response.status === 200 && 'ref' in response) {
+      if (!('error' in response)) {
         dispatchApp({
           type: AppTypes.TOAST_ADD,
           status: 'success',
@@ -430,7 +430,7 @@ const ManageElection = ({ token }:{token:(string|undefined)}) => {
   const handleClosing = async () => {
     setWaiting(true);
     const response = await closeElection(election.ref, token);
-    if (response.status === 200 && 'ref' in response) {
+    if (!('error' in response)) {
       dispatchApp({
         type: AppTypes.TOAST_ADD,
         status: 'success',

--- a/pages/votes/[pid]/[[...tid]].tsx
+++ b/pages/votes/[pid]/[[...tid]].tsx
@@ -16,6 +16,9 @@ import {
   BallotPayload,
   ErrorPayload,
   ELECTION_FINISHED_ERROR_CODE,
+  UNAUTHORIZED_ERROR_CODE,
+  WRONG_ELECTION_ERROR_CODE,
+  NOT_FOUND_ERROR_CODE,
 } from '@services/api';
 import {
   useBallot,
@@ -171,6 +174,18 @@ const VoteBallot = ({election, electionRef, token, previousBallot}: VoteInterfac
           message={t('vote.error-closed-message')}
           buttonText={t('vote.go-to-results')}
           onButtonClick={() => router.push(url.toString())}
+        />;
+      } else if (
+          error.error === UNAUTHORIZED_ERROR_CODE ||
+          error.error === WRONG_ELECTION_ERROR_CODE ||
+          error.error === NOT_FOUND_ERROR_CODE
+      ) {
+        // These errors strongly suggest the user's link/token is bad.
+        return <ErrorDisplay
+          title={t('vote.error-invalid-link-title')}
+          message={t('vote.error-invalid-link-message')}
+          buttonText={t('common.back-homepage')}
+          onButtonClick={() => router.push('/')}
         />;
       } else {
         return <ErrorDisplay

--- a/pages/votes/[pid]/[[...tid]].tsx
+++ b/pages/votes/[pid]/[[...tid]].tsx
@@ -19,6 +19,7 @@ import {
   UNAUTHORIZED_ERROR_CODE,
   WRONG_ELECTION_ERROR_CODE,
   NOT_FOUND_ERROR_CODE,
+  ELECTION_NOT_STARTED_ERROR_CODE,
 } from '@services/api';
 import {
   useBallot,
@@ -174,6 +175,13 @@ const VoteBallot = ({election, electionRef, token, previousBallot}: VoteInterfac
           message={t('vote.error-closed-message')}
           buttonText={t('vote.go-to-results')}
           onButtonClick={() => router.push(url.toString())}
+        />;
+      } else if (error.error === ELECTION_NOT_STARTED_ERROR_CODE) {
+        return <ErrorDisplay
+          title={t('vote.error-not-started-title')}
+          message={t('vote.error-not-started-message')}
+          buttonText={t('common.go-home', 'Go to Homepage')}
+          onButtonClick={() => router.push('/')}
         />;
       } else if (
           error.error === UNAUTHORIZED_ERROR_CODE ||

--- a/pages/votes/[pid]/[[...tid]].tsx
+++ b/pages/votes/[pid]/[[...tid]].tsx
@@ -76,7 +76,7 @@ export async function getServerSideProps({query: {pid, tid}, locale}) {
       election,
       electionRef,
       token: tid || null,
-      previousBallot: ballot && ballot.status != 404 ? ballot : null,
+      previousBallot: ballot && !('error' in ballot) ? ballot : null,
     },
   };
 }

--- a/public/locales/en/resource.json
+++ b/public/locales/en/resource.json
@@ -41,7 +41,7 @@
     "common.share": "Share the application Better Vote",
     "common.share-short": "Share the application",
     "common.save": "Save",
-    "common.go-back": "Revenir en arrière",
+    "common.go-back": "Go back",
     "common.back-homepage": "Return to home page",
     "common.support-us": "Support us",
     "common.thumbnail": "Thumbnail",

--- a/public/locales/en/resource.json
+++ b/public/locales/en/resource.json
@@ -237,6 +237,8 @@
     "vote.support-desc": "Better Vote is a transparent and non-profit association. By joining the association, you contribute to finance its functioning and activities.",
     "vote.error-closed-title": "Vote Closed",
     "vote.error-closed-message": "This election was closed while you were voting. Your vote has not been cast.",
+    "vote.error-invalid-link-title": "Invalid Link",
+    "vote.error-invalid-link-message": "This voting link is invalid or has already been used. Please check the link or contact the organizer.",
     "vote.error-generic-title": "An Error Occurred",
     "vote.error-generic-message": "Your vote could not be submitted. This may be due to an invalid link or a network issue.",
     "vote.thanks": "Thanks for your participation!"

--- a/public/locales/en/resource.json
+++ b/public/locales/en/resource.json
@@ -59,6 +59,7 @@
     "common.the-vote": "The vote",
     "common.the-params": "The parameters",
     "common.welcome": "Welcome!",
+    "common.reload": "Try again",
     "error.at-least-2-candidates": "At least two candidates are required.",
     "error.cant-set-ongoing": "You can not set this parameter for an ongoing election.",
     "error.ended-election": "The election has ended",
@@ -236,5 +237,7 @@
     "vote.support-desc": "Better Vote is a transparent and non-profit association. By joining the association, you contribute to finance its functioning and activities.",
     "vote.error-closed-title": "Vote Closed",
     "vote.error-closed-message": "This election was closed while you were voting. Your vote has not been cast.",
+    "vote.error-generic-title": "An Error Occurred",
+    "vote.error-generic-message": "Your vote could not be submitted. This may be due to an invalid link or a network issue.",
     "vote.thanks": "Thanks for your participation!"
 }

--- a/public/locales/en/resource.json
+++ b/public/locales/en/resource.json
@@ -237,6 +237,8 @@
     "vote.support-desc": "Better Vote is a transparent and non-profit association. By joining the association, you contribute to finance its functioning and activities.",
     "vote.error-closed-title": "Vote Closed",
     "vote.error-closed-message": "This election was closed while you were voting. Your vote has not been cast.",
+    "vote.error-not-started-title": "Not Yet Open",
+    "vote.error-not-started-message": "This election has not opened for voting yet. Please come back later.",
     "vote.error-invalid-link-title": "Invalid Link",
     "vote.error-invalid-link-message": "This voting link is invalid or has already been used. Please check the link or contact the organizer.",
     "vote.error-generic-title": "An Error Occurred",

--- a/public/locales/fr/resource.json
+++ b/public/locales/fr/resource.json
@@ -237,6 +237,8 @@
     "vote.support-desc": "Mieux Voter est une association transpartisane et sans but lucratif. En adhérant à l’association, vous contribuez à financer son fonctionnement et ses activités.",
     "vote.error-closed-title": "Election clôturée",
     "vote.error-closed-message": "Cette élection s'est terminée pendant que vous votiez. Votre vote n'a pas été pris en compte.",
+    "vote.error-not-started-title": "Pas encore commencé",
+    "vote.error-not-started-message": "Le vote n'est pas encore ouvert. Merci de revenir plus tard.",
     "vote.error-invalid-link-title": "Lien invalide",
     "vote.error-invalid-link-message": "Ce lien de vote est invalide ou a déjà été utilisé. Vérifiez le lien ou contactez les organisateurs",
     "vote.error-generic-title": "Une erreur est survenue",

--- a/public/locales/fr/resource.json
+++ b/public/locales/fr/resource.json
@@ -59,6 +59,7 @@
     "common.vote": "Voter",
     "common.welcome": "Bienvenue !",
     "common.results": "Résultats",
+    "common.reload": "Essayer encore",
     "error.help": "Besoin d'aide ?",
     "error.wrong-csv-format": "L'interprétation des résultats à partir de votre CSV a échoué. Vérifiez le format et les valeurs que vous avez utilisé. (Téléchargé les résultats CSV d'un vote existant pour observer un format valide)",
     "error.cant-set-ongoing": "Vous ne pouvez pas modifier ce paramètre pour une élection déjà démarrée.",
@@ -236,6 +237,8 @@
     "vote.support-desc": "Mieux Voter est une association transpartisane et sans but lucratif. En adhérant à l’association, vous contribuez à financer son fonctionnement et ses activités.",
     "vote.error-closed-title": "Election clôturée",
     "vote.error-closed-message": "Cette élection s'est terminée pendant que vous votiez. Votre vote n'a pas été pris en compte.",
+    "vote.error-generic-title": "Une erreur est survenue",
+    "vote.error-generic-message": "Votre vote n'a pas pu être pris en compte. Cela peut être dû à un lien invalide ou à un problème de réseau.",
     "vote.thanks": "Merci de votre participation !",
     "grades.mediocre": "Médiocre"
 }

--- a/public/locales/fr/resource.json
+++ b/public/locales/fr/resource.json
@@ -237,6 +237,8 @@
     "vote.support-desc": "Mieux Voter est une association transpartisane et sans but lucratif. En adhérant à l’association, vous contribuez à financer son fonctionnement et ses activités.",
     "vote.error-closed-title": "Election clôturée",
     "vote.error-closed-message": "Cette élection s'est terminée pendant que vous votiez. Votre vote n'a pas été pris en compte.",
+    "vote.error-invalid-link-title": "Lien invalide",
+    "vote.error-invalid-link-message": "Ce lien de vote est invalide ou a déjà été utilisé. Vérifiez le lien ou contactez les organisateurs",
     "vote.error-generic-title": "Une erreur est survenue",
     "vote.error-generic-message": "Votre vote n'a pas pu être pris en compte. Cela peut être dû à un lien invalide ou à un problème de réseau.",
     "vote.thanks": "Merci de votre participation !",

--- a/services/api.ts
+++ b/services/api.ts
@@ -434,33 +434,19 @@ export const castBallot = (
   }
 };
 
-export const UNKNOWN_ELECTION_ERROR = 'E1:';
-export const ONGOING_ELECTION_ERROR = 'E2:';
-export const NO_VOTE_ERROR = 'E3:';
-export const ELECTION_NOT_STARTED_ERROR = 'E4:';
-export const ELECTION_FINISHED_ERROR = 'E5:';
-export const INVITATION_ONLY_ERROR = 'E6:';
-export const UNKNOWN_TOKEN_ERROR = 'E7:';
-export const USED_TOKEN_ERROR = 'E8:';
-export const WRONG_ELECTION_ERROR = 'E9:';
-export const API_ERRORS = [
-  UNKNOWN_TOKEN_ERROR,
-  ONGOING_ELECTION_ERROR,
-  NO_VOTE_ERROR,
-  ELECTION_NOT_STARTED_ERROR,
-  ELECTION_FINISHED_ERROR,
-  INVITATION_ONLY_ERROR,
-  UNKNOWN_TOKEN_ERROR,
-  USED_TOKEN_ERROR,
-  WRONG_ELECTION_ERROR,
-];
-
-export const apiErrors = (error: string): string => {
-  const errorCode = `${error.split(':')[0]}:`;
-
-  if (API_ERRORS.includes(errorCode)) {
-    return `error.${error.split(':')[0].toLowerCase()}`;
-  } else {
-    return 'error.catch22';
-  }
-};
+export const BAD_REQUEST_ERROR_CODE = 'BAD_REQUEST';
+export const ELECTION_FINISHED_ERROR_CODE = 'ELECTION_FINISHED';
+export const ELECTION_IS_ACTIVE_ERROR_CODE = 'ELECTION_IS_ACTIVE';
+export const ELECTION_NOT_STARTED_ERROR_CODE = 'ELECTION_NOT_STARTED';
+export const ELECTION_RESTRICTED_ERROR_CODE = 'ELECTION_RESTRICTED';
+export const FORBIDDEN_ERROR_CODE = 'FORBIDDEN';
+export const IMMUTABLE_IDS_ERROR_CODE = 'IMMUTABLE_IDS';
+export const INCONSISTENT_BALLOT_ERROR_CODE = 'INCONSISTENT_BALLOT';
+export const INVALID_DATE_CONFIGURATION_ERROR_CODE = 'INVALID_DATE_CONFIGURATION';
+export const NO_RECORDED_VOTES_ERROR_CODE = 'NO_RECORDED_VOTES';
+export const NOT_FOUND_ERROR_CODE = 'NOT_FOUND';
+export const RESULTS_HIDDEN_ERROR_CODE = 'RESULTS_HIDDEN';
+export const SCHEMA_VALIDATION_ERROR_CODE = 'SCHEMA_VALIDATION_ERROR';
+export const UNAUTHORIZED_ERROR_CODE = 'UNAUTHORIZED';
+export const VALIDATION_ERROR_CODE = 'VALIDATION_ERROR';
+export const WRONG_ELECTION_ERROR_CODE = 'WRONG_ELECTION';

--- a/services/api.ts
+++ b/services/api.ts
@@ -34,12 +34,8 @@ export interface ErrorMessage {
 }
 
 export interface ErrorPayload {
-  detail: Array<ErrorMessage>;
-}
-
-export interface HTTPPayload {
-  status: number;
-  message: string;
+  error: string;   // e.g., "ELECTION_FINISHED"
+  message: string; // e.g., "The election has finished."
 }
 
 export interface ElectionPayload {
@@ -170,7 +166,7 @@ export const updateElection = async (
   randomOrder: boolean,
   authForResult:boolean,
   token: string,
-): Promise<ElectionUpdatedPayload | HTTPPayload> => {
+): Promise<ElectionUpdatedPayload | ErrorPayload> => {
   /**
    * Create an election from its title, its candidates and a bunch of options
    */
@@ -208,14 +204,14 @@ export const updateElection = async (
     return { status: 200, ...payload };
   } catch (e) {
     console.error(e);
-    return { status: 400, message: `Unknown API error: ${e}` };
+    return { error: 'CLIENT_ERROR', message: `Unknown API error: ${e}` };
   }
 };
 
 export const closeElection = async (
   ref: string,
   token: string
-): Promise<ElectionUpdatedPayload | HTTPPayload> => {
+): Promise<ElectionUpdatedPayload | ErrorPayload> => {
   const endpoint = new URL(api.routesServer.setElection, URL_SERVER);
 
   try {
@@ -238,14 +234,14 @@ export const closeElection = async (
     return { status: 200, ...payload };
   } catch (e) {
     console.error(e);
-    return { status: 400, message: `Unknown API error: ${e}` };
+    return { error: 'CLIENT_ERROR', message: `Unknown API error: ${e}` };
   }
 };
 
 export const openElection = async (
   election: ElectionContextInterface,
   token: string
-): Promise<ElectionUpdatedPayload | HTTPPayload> => {
+): Promise<ElectionUpdatedPayload | ErrorPayload> => {
   const endpoint = new URL(api.routesServer.setElection, URL_SERVER);
 
   try {
@@ -280,7 +276,7 @@ export const openElection = async (
     return { status: 200, ...payload };
   } catch (e) {
     console.error(e);
-    return { status: 400, message: `Unknown API error: ${e}` };
+    return { error: 'CLIENT_ERROR', message: `Unknown API error: ${e}` };
   }
 };
 
@@ -289,7 +285,7 @@ export const openElection = async (
  */
 export const getResults = async (
   pid: string, token:string|null = null
-): Promise<ResultsPayload | HTTPPayload> => {
+): Promise<ResultsPayload | ErrorPayload> => {
   const endpoint = new URL(
     api.routesServer.getResults.replace(new RegExp(':slug', 'g'), pid),
     URL_SERVER
@@ -304,20 +300,18 @@ export const getResults = async (
     });
 
     if (response.status != 200) {
-      const payload = await response.json();
-      return { status: response.status, ...payload };
+      return await response.json();
     }
-    const payload = await response.json();
-    return { ...payload, status: response.status };
+    return await response.json();
   } catch (error) {
     console.error(error);
-    return { status: 400, message: `Unknown API error: ${error}` };
+    return { error: 'CLIENT_ERROR', message: `Unknown API error: ${error}` };
   }
 };
 
 export const getElection = async (
   pid: string
-): Promise<ElectionPayload | HTTPPayload> => {
+): Promise<ElectionPayload | ErrorPayload> => {
   /**
    * Fetch data from external API
    */
@@ -331,20 +325,18 @@ export const getElection = async (
     const response = await fetch(endpoint.href);
 
     if (response.status != 200) {
-      const payload = await response.json();
-      return { status: response.status, message: payload };
+      return await response.json();
     }
-    const payload = await response.json();
-    return { ...payload, status: response.status };
+    return await response.json();
   } catch (error) {
-    return { status: 400, message: 'Unknown API error' };
+    return { error: 'CLIENT_ERROR', message: 'Unknown API error' };
   }
 };
 
 export const getProgress = async (
   pid: string,
   token: string
-): Promise<ProgressPayload | HTTPPayload> => {
+): Promise<ProgressPayload | ErrorPayload> => {
   /**
    * Fetch progress (number of voters) from external API
    */
@@ -363,13 +355,11 @@ export const getProgress = async (
       },
     });
     if (response.status != 200) {
-      const payload = await response.json();
-      return { status: response.status, message: payload };
+      return await response.json();
     }
-    const payload = await response.json();
-    return { ...payload, status: response.status };
+    return await response.json();
   } catch (error) {
-    return { status: 400, message: 'Unknown API error' };
+    return { error: 'CLIENT_ERROR', message: 'Unknown API error' };
   }
 };
 
@@ -378,7 +368,7 @@ export const getProgress = async (
  */
 export const getBallot = async (
   token: string
-): Promise<ElectionPayload | HTTPPayload> => {
+): Promise<ElectionPayload | ErrorPayload> => {
   const path = api.routesServer.voteElection;
   const endpoint = new URL(path, URL_SERVER);
 
@@ -395,13 +385,12 @@ export const getBallot = async (
     });
 
     if (response.status != 200) {
-      return { status: response.status, message: 'Can not load this ballot' };
+      return await response.json();
     }
 
-    const payload = await response.json();
-    return { ...payload, status: response.status };
+    return await response.json();
   } catch (error) {
-    return { status: 400, message: 'Unknown API error' };
+    return { error: 'CLIENT_ERROR', message: 'Unknown API error' };
   }
 };
 


### PR DESCRIPTION
I recently submitted the https://github.com/MieuxVoter/majority-judgment-api-python/pull/68 backend PR which completely changes the errors messages sent by the backend so they are like:

```
{ 
    "error": "THE_ERROR", 
    "message": "Explanation sentence"
}
```

This PR makes the corresponding changes to the frontend. We can see that it allows us to better distinguish the errors sent by the backend by using the "error" part of the payload.

I haven't tested this yet because it needs an updated backend running locally, but I don't think there should be a lot of issues with this. I will try to test it soon anyway. 
